### PR TITLE
Fix selecting color by ThemeSelector

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "datocms-plugin-sdk": "^0.3.34",
     "datocms-react-ui": "^0.3.34",
+    "lodash": "^4.17.21",
     "polished": "^4.1.3",
     "react": "^17.0.0",
     "react-dom": "^17.0.0"

--- a/src/ThemeSelector.tsx
+++ b/src/ThemeSelector.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react";
 import { parseToRgb, rgb } from "polished";
+import { get } from "lodash";
 import styles from "./ThemeSelector.module.css";
 import { RenderFieldExtensionCtx } from "datocms-plugin-sdk";
 import { Button } from "datocms-react-ui";
@@ -53,8 +54,9 @@ export function ThemeSelector({ ctx }: Props) {
   }, [localColors, globalColors]);
 
   const isRequired = Boolean(ctx.field.attributes.validators?.required);
-  const currentColor = ctx.formValues[ctx.fieldPath]
-    ? rgb(ctx.formValues[ctx.fieldPath] as RgbColor)
+  const selectedColor = get(ctx.formValues, ctx.fieldPath);
+  const currentColor = selectedColor
+    ? rgb(selectedColor as RgbColor)
     : undefined;
 
   if (!colors.length) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -635,6 +635,11 @@ json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"


### PR DESCRIPTION
I wish you could merge this as soon as it possible. There is a problem that selected color is not visually selected as it should.
It is caused by `currentColor` being undefined. Array access  is not proper way for accessing deep properties. Instead You can use lodash `get`:[https://lodash.com/docs/4.17.15#get]( https://lodash.com/docs/4.17.15#get)